### PR TITLE
Add .npm to .gitignore for submodule inclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .build*
+.npm


### PR DESCRIPTION
Meteor will dump .npm directories into all packages with npm dependencies.  This makes git submodules sad since the parent repo can't see into submodules and just sees dirty state.
