### PR TITLE
Small refactor to be more React-y

### DIFF
--- a/examples/leaderboard/leaderboard.jsx
+++ b/examples/leaderboard/leaderboard.jsx
@@ -35,7 +35,7 @@ var Leaderboard = React.createClass({
 
     return (
       <Player
-        id={model._id}
+        key={model._id}
         name={model.name}
         score={model.score}
         className={model._id === _id ? "selected" : ""}


### PR DESCRIPTION
The selected member of a collection is part of the state of that collection. The collection not the unit should then be responsible for selecting. Benefits, Meteor won't need to auto call `setState` on each `Player` component now. Instead the leaderboard collection component will try to rerender each `Player` and React can prune away any changes that aren't needed.

Also changed `<Player id=` to `<Player key=` as mentioned in the React docs.
