### PR TITLE
reduce rendering with shouldComponentUpdate

### DIFF
--- a/examples/leaderboard/leaderboard.jsx
+++ b/examples/leaderboard/leaderboard.jsx
@@ -88,7 +88,12 @@ var Leaderboard = ReactMeteor.createClass({
 });
 
 var Player = React.createClass({
+  shouldComponentUpdate: function(nextProps, nextState){
+    var { name, score, ...rest } = this.props;
+    return name !== nextProps.name || score !== nextProps.score || rest.className !== nextProps.className;
+  },
   render: function() {
+    console.log('rendering: ', this.props.name);
     var { name, score, ...rest } = this.props;
     return <div {...rest} className={cx("player", rest.className)}>
       <span className="name">{name}</span>

--- a/examples/leaderboard/leaderboard.jsx
+++ b/examples/leaderboard/leaderboard.jsx
@@ -93,7 +93,6 @@ var Player = React.createClass({
     return name !== nextProps.name || score !== nextProps.score || rest.className !== nextProps.className;
   },
   render: function() {
-    console.log('rendering: ', this.props.name);
     var { name, score, ...rest } = this.props;
     return <div {...rest} className={cx("player", rest.className)}>
       <span className="name">{name}</span>


### PR DESCRIPTION
Very handy package and example.  Thanks.

Stopping unnecessary renders is more like the current Blaze / Tracker behaviour though I understand it is less important for React since it diffs the virtual DOM.  But I thought it would be good for others that transition from Blaze to React by using this leaderboard example to see that `shouldComponentUpdate()` is available.  
