### PR TITLE
setProps if they change reactively

### DIFF
--- a/src/ReactMeteor.js
+++ b/src/ReactMeteor.js
@@ -157,11 +157,16 @@ ReactMeteor = {
       );
 
       template.onRendered(function() {
-        this._reactComponent = renderInPlaceOfNode(
+        var self = this;
+        self._reactComponent = renderInPlaceOfNode(
           // Equivalent to <Cls {...this.data} />:
-          React.createElement(Cls, this.data || {}),
-          this.find("span")
+          React.createElement(Cls, self.data || {}),
+          self.find("span")
         );
+        self.autorun(function (){
+          self._reactComponent.setProps(Template.currentData());
+        });
+
       });
 
       template.onDestroyed(function() {


### PR DESCRIPTION
Currently, if a React template gets passed reactive props (by a Blaze template), it never updates to reflect them.  

This updates the props with an autorun, so now a React template can be used inside a Blaze template receiving props from reactive helper functions.  For example, with a `players` helper defined on `UI.body` the leaderboard example could call `{{> Leaderboard players=players}}`.
